### PR TITLE
fix: 🐛 Removed duplicate setting of widgetEnvironment

### DIFF
--- a/packages/create-widget/template/server/app.js
+++ b/packages/create-widget/template/server/app.js
@@ -53,11 +53,6 @@ app
       const html = await widget.mount();
       const info = await widget.info();
 
-      info.props = {
-        ...info.props,
-        environment: widgetEnvironment,
-      };
-
       res.json({ ...info, html });
     })
   )

--- a/packages/create-widget/template/src/widget.js
+++ b/packages/create-widget/template/src/widget.js
@@ -25,9 +25,13 @@ export const widgetProperties = {
     widget.setState({ counter: 0 });
   },
   load(widget) {
+    // We don't want to set environment into app state
+    // eslint-disable-next-line no-unused-vars
+    const { environment, ...restProps } = widget.props;
+
     return {
       counter: 0,
-      ...widget.props,
+      ...restProps,
     };
   },
 };


### PR DESCRIPTION
Removed duplicate setting of widgetEnvironment into the API call, since
it's already returned in the info method along with rest of the props.