### PR TITLE
Copy all relevant properties of Response

### DIFF
--- a/packages/plugin-http-client/src/index.js
+++ b/packages/plugin-http-client/src/index.js
@@ -153,7 +153,18 @@ export function transformBody() {
 }
 
 function copyResponse(response) {
-  const { body, headers, ok, redirected, status, statusText, trailers, type, url, useFinalURL } = response;
+  const {
+    body,
+    headers,
+    ok,
+    redirected,
+    status,
+    statusText,
+    trailers,
+    type,
+    url,
+    useFinalURL,
+  } = response;
 
   return {
     body,
@@ -166,5 +177,5 @@ function copyResponse(response) {
     type,
     url,
     useFinalURL,
-  }
+  };
 }

--- a/packages/plugin-http-client/src/index.js
+++ b/packages/plugin-http-client/src/index.js
@@ -131,7 +131,9 @@ export function transformBody() {
         }
       }
 
-      let newResponse = { ...response, body };
+      let newResponse = copyResponse(response);
+      newResponse.body = body;
+
       return [request, newResponse];
     },
     async transformRequest(request) {
@@ -148,4 +150,21 @@ export function transformBody() {
       return [request];
     },
   };
+}
+
+function copyResponse(response) {
+  const { body, headers, ok, redirected, status, statusText, trailers, type, url, useFinalURL } = response;
+
+  return {
+    body,
+    headers,
+    ok,
+    redirected,
+    status,
+    statusText,
+    trailers,
+    type,
+    url,
+    useFinalURL,
+  }
 }


### PR DESCRIPTION
By specification, Response properties are read-only and accessible
only through getters. Because of that, neither Object.assign
nor object spread operator will copy them. It's necessary to assign
them manually.