### PR TITLE
Fix preset-env setting

### DIFF
--- a/packages/tools/webpack.cjs
+++ b/packages/tools/webpack.cjs
@@ -186,7 +186,7 @@ function applyES5Transformation(config, options = {}) {
   const babelPresetEnv = [
     '@babel/preset-env',
     {
-      modules: false,
+      modules: 'cjs',
       useBuiltIns: 'usage',
       corejs: { version: 3, proposals: false },
     },


### PR DESCRIPTION
To be able to include CJS modules in MJS, `@babel/preset-env` must be set to `cjs`.