### PR TITLE
docs: ✏️ Make plugin READMEs specific

### DIFF
--- a/packages/plugin-component/README.md
+++ b/packages/plugin-component/README.md
@@ -1,16 +1,9 @@
-<center>
-  <h1 style="font-family: Helvetica, Arial, sans-serif; font-size:60px;">Merkur</h1>
-</center>
+# Merkur - plugin-component
 
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/core/latest.svg)](https://www.npmjs.com/package/@merkur/core)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/core/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+The component plugin is one of the base Merkur plugins which adds base lifecycle methods and properties to your widget. Other Merkur plugins can depend on it.
 
-# Merkur
+**[Documentation for @merkur/plugin-component](https://merkur.js.org/docs/component-plugin).**
+
+## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
-
-## Links
-
-Documentation for [@merkur/plugin-component](https://merkur.js.org/docs/component-plugin).

--- a/packages/plugin-component/README.md
+++ b/packages/plugin-component/README.md
@@ -7,3 +7,8 @@ The component plugin is one of the base Merkur plugins which adds base lifecycle
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
+
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-component/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-component)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-component/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)

--- a/packages/plugin-component/README.md
+++ b/packages/plugin-component/README.md
@@ -1,5 +1,10 @@
 # Merkur - plugin-component
 
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-component/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-component)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-component/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+
 The component plugin is one of the base Merkur plugins which adds base lifecycle methods and properties to your widget. Other Merkur plugins can depend on it.
 
 **[Documentation for @merkur/plugin-component](https://merkur.js.org/docs/component-plugin).**
@@ -7,8 +12,3 @@ The component plugin is one of the base Merkur plugins which adds base lifecycle
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
-
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-component/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-component)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-component/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)

--- a/packages/plugin-error/README.md
+++ b/packages/plugin-error/README.md
@@ -14,3 +14,8 @@
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
+
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-error/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-error)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-error/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)

--- a/packages/plugin-error/README.md
+++ b/packages/plugin-error/README.md
@@ -1,16 +1,16 @@
-<center>
-  <h1 style="font-family: Helvetica, Arial, sans-serif; font-size:60px;">Merkur</h1>
-</center>
+# Merkur - plugin-error
 
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/core/latest.svg)](https://www.npmjs.com/package/@merkur/core)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/core/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+`merkur/plugin-error` adds semi-automatic error handling to your Merkur widget: 
 
-# Merkur
+* Return a custom HTTP status based on thrown error
+* Render valid JSON with error code and message
+* Render an error page
+* Run arbitrary code on error (e.g. to log/report the error)
+* Catch unhandled promise errors
+
+
+**[Full documentation for @merkur/plugin-error](https://merkur.js.org/docs/error-plugin).**
+
+## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
-
-## Links
-
-Documentation for [@merkur/plugin-error](https://merkur.js.org/docs/error-plugin).

--- a/packages/plugin-error/README.md
+++ b/packages/plugin-error/README.md
@@ -1,5 +1,10 @@
 # Merkur - plugin-error
 
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-error/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-error)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-error/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+
 `merkur/plugin-error` adds semi-automatic error handling to your Merkur widget: 
 
 * Return a custom HTTP status based on thrown error
@@ -14,8 +19,3 @@
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
-
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-error/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-error)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-error/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)

--- a/packages/plugin-event-emitter/README.md
+++ b/packages/plugin-event-emitter/README.md
@@ -1,16 +1,9 @@
-<center>
-  <h1 style="font-family: Helvetica, Arial, sans-serif; font-size:60px;">Merkur</h1>
-</center>
+# Merkur - plugin-event-emiter
 
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/core/latest.svg)](https://www.npmjs.com/package/@merkur/core)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/core/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+The event emitter plugin is one of the base Merkur plugins which adds event methods to your widget. Other Merkur plugins can depend on it.
 
-# Merkur
+**[Documentation for @merkur/plugin-event-emitter](https://merkur.js.org/docs/event-emitter-plugin).**
+
+## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
-
-## Links
-
-Documentation for [@merkur/plugin-event-emitter](https://merkur.js.org/docs/event-emitter-plugin).

--- a/packages/plugin-event-emitter/README.md
+++ b/packages/plugin-event-emitter/README.md
@@ -1,5 +1,10 @@
 # Merkur - plugin-event-emiter
 
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-event-emitter/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-event-emitter)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-event-emitter/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+
 The event emitter plugin is one of the base Merkur plugins which adds event methods to your widget. Other Merkur plugins can depend on it.
 
 **[Documentation for @merkur/plugin-event-emitter](https://merkur.js.org/docs/event-emitter-plugin).**
@@ -7,8 +12,3 @@ The event emitter plugin is one of the base Merkur plugins which adds event meth
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
-
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-event-emitter/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-event-emitter)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-event-emitter/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)

--- a/packages/plugin-event-emitter/README.md
+++ b/packages/plugin-event-emitter/README.md
@@ -7,3 +7,8 @@ The event emitter plugin is one of the base Merkur plugins which adds event meth
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
+
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-event-emitter/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-event-emitter)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-event-emitter/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)

--- a/packages/plugin-http-client/README.md
+++ b/packages/plugin-http-client/README.md
@@ -7,3 +7,8 @@ The HTTP client plugin adds http property to your widget with a request method. 
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
+
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-http-client/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-http-client)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-http-client/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)

--- a/packages/plugin-http-client/README.md
+++ b/packages/plugin-http-client/README.md
@@ -1,16 +1,9 @@
-<center>
-  <h1 style="font-family: Helvetica, Arial, sans-serif; font-size:60px;">Merkur</h1>
-</center>
+# Merkur - plugin-http-client
 
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/core/latest.svg)](https://www.npmjs.com/package/@merkur/core)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/core/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+The HTTP client plugin adds http property to your widget with a request method. Under the hood this plugin uses native browser fetch API and for server-side the node-fetch polyfill.
 
-# Merkur
+**[Documentation for @merkur/plugin-http-client](https://merkur.js.org/docs/http-client-plugin).**
+
+## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
-
-## Links
-
-Documentation for [@merkur/plugin-http-client](https://merkur.js.org/docs/http-client-plugin).

--- a/packages/plugin-http-client/README.md
+++ b/packages/plugin-http-client/README.md
@@ -1,5 +1,10 @@
 # Merkur - plugin-http-client
 
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-http-client/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-http-client)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-http-client/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+
 The HTTP client plugin adds http property to your widget with a request method. Under the hood this plugin uses native browser fetch API and for server-side the node-fetch polyfill.
 
 **[Documentation for @merkur/plugin-http-client](https://merkur.js.org/docs/http-client-plugin).**
@@ -7,8 +12,3 @@ The HTTP client plugin adds http property to your widget with a request method. 
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
-
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-http-client/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-http-client)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-http-client/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)

--- a/packages/plugin-router/README.md
+++ b/packages/plugin-router/README.md
@@ -5,3 +5,9 @@ The router plugin enables the use of routes in a widget.
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
+
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-router/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-router)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-router/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+

--- a/packages/plugin-router/README.md
+++ b/packages/plugin-router/README.md
@@ -1,13 +1,14 @@
 # Merkur - plugin-router
 
+[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
+[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-router/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-router)
+![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-router/latest)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+
 The router plugin enables the use of routes in a widget. 
 
 ## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
 
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/plugin-router/latest.svg)](https://www.npmjs.com/package/@merkur/plugin-router)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/plugin-router/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 

--- a/packages/plugin-router/README.md
+++ b/packages/plugin-router/README.md
@@ -1,54 +1,7 @@
-<center>
-  <h1 style="font-family: Helvetica, Arial, sans-serif; font-size:60px;">Merkur</h1>
-</center>
+# Merkur - plugin-router
 
-[![Build Status](https://travis-ci.com/mjancarik/merkur.svg?branch=master)](https://travis-ci.com/mjancarik/merkur)
-[![NPM package version](https://img.shields.io/npm/v/@merkur/core/latest.svg)](https://www.npmjs.com/package/@merkur/core)
-![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@merkur/core/latest)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+The router plugin enables the use of routes in a widget. 
 
-# Merkur
+## About Merkur
 
 The [Merkur](https://merkur.js.org/) is tiny extensible javascript library for front-end microservices. It allows by default server side rendering for loading performance boost. You can connect it with other frameworks or languages because merkur defines easy API. You can use one of four predefined template's library [React](https://reactjs.org/), [Preact](https://preactjs.com/), [hyperHTML](https://viperhtml.js.org/hyper.html) and [µhtml](https://github.com/WebReflection/uhtml#readme) but you can easily extend for others.
-
-## Getting started
-
-```bash
-npx @merkur/create-widget <name>
-
-cd name
-
-npm run dev // Point your browser at http://localhost:4444/
-```
-<p align="center">
-  <img alt="Merkur example, hello widget" src="https://raw.githubusercontent.com/mjancarik/merkur/master/images/hello-widget.png" />
-</p>
-
-## API
-
-Point your browser at `http://localhost:4444/widget`.
-
-```json
-{
-  "name":"my-widget",
-  "version":"0.0.1",
-  "props":{},
-  "state":{"counter":0},
-  "assets":[
-    {
-      "name": "widget.js",
-      "type": "script",
-      "source": {
-        "es9": "http://localhost:4444/static/es9/widget.6961af42bfa3596bb147.js",
-        "es5": "http://localhost:4444/static/es5/widget.31c5090d8c961e43fade.js"
-      }
-    },
-    {
-      "name": "widget.css",
-      "type": "stylesheet",
-      "source": "http://localhost:4444/static/es9/widget.814e0cb568c7ddc0725d.css"
-    }
-  ],
-  "html":"\n      <div class=\"merkur__page\">\n        <div class=\"merkur__headline\">\n          <div class=\"merkur__view\">\n            \n    <div class=\"merkur__icon\">\n      <img src=\"http://localhost:4444/static/merkur-icon.png\" alt=\"Merkur\">\n    </div>\n  \n            \n    <h1>Welcome to <a href=\"https://github.com/mjancarik/merkur\">MERKUR</a>,<br> a javascript library for front-end microservices.</h1>\n  \n            \n    <p>The widget's name is <strong>my-widget@0.0.1</strong>.</p>\n  \n          </div>\n        </div>\n        <div class=\"merkur__view\">\n          \n    <div>\n      <h2>Counter widget:</h2>\n      <p>Count: 0</p>\n      <button onclick=\"return ((...rest) =&gt; {\n        return originalFunction(widget, ...rest);\n      }).call(this, event)\">\n        increase counter\n      </button>\n      <button onclick=\"return ((...rest) =&gt; {\n        return originalFunction(widget, ...rest);\n      }).call(this, event)\">\n        reset counter\n      </button>\n    </div>\n  \n        </div>\n      </div>\n  "
-}
-```


### PR DESCRIPTION
Make plugin READMEs specific to the plugin to make sure the reader doesn't overlook the link to documentation included.