### PR TITLE
fix: 🐛 check presence of inlineStyles just in head

### DIFF
--- a/packages/integration/src/index.js
+++ b/packages/integration/src/index.js
@@ -56,7 +56,7 @@ function _loadStyle(asset) {
 }
 
 function loadStyleAssets(assets) {
-  const styleElements = document.getElementsByTagName('style');
+  const styleElements = document.head.getElementsByTagName('style');
   const stylesToRender = assets.filter(
     (asset) =>
       asset.source &&


### PR DESCRIPTION
We want to be able to  move inlineStyles from MerkurComponent to head,
therefore we need to be able to double it for a moment.