### PR TITLE
feat: 🎸 Automatically generate free port for livereload server

### DIFF
--- a/packages/create-widget/template/server/routes/playground/playground.ejs
+++ b/packages/create-widget/template/server/routes/playground/playground.ejs
@@ -4,6 +4,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <script>
+    window.__merkur_dev__ = window.__merkur_dev__ || {};
+    window.__merkur_dev__.webSocketOptions = {
+      url: `ws://localhost:${<%- process.env.MERKUR_PLAYGROUND_LIVERELOAD_PORT %>}`
+    };
+  </script>
   <script src="/@merkur/tools/static/livereload.js"></script>
   <% assets.forEach((asset) => { %>
     <%if (asset.type === 'stylesheet') { %>

--- a/packages/create-widget/views/hyper/template/webpack.config.js
+++ b/packages/create-widget/views/hyper/template/webpack.config.js
@@ -7,11 +7,11 @@ const {
   pipe,
 } = require('@merkur/tool-webpack');
 
-createLiveReloadServer();
-
-module.exports = Promise.all([
-  pipe(createWebConfig)(),
-  pipe(createWebConfig, applyES5Transformation)(),
-  pipe(createWebConfig, applyES9Transformation)(),
-  pipe(createNodeConfig)(),
-]);
+module.exports = createLiveReloadServer().then(() =>
+  Promise.all([
+    pipe(createWebConfig)(),
+    pipe(createWebConfig, applyES5Transformation)(),
+    pipe(createWebConfig, applyES9Transformation)(),
+    pipe(createNodeConfig)(),
+  ])
+);

--- a/packages/create-widget/views/preact/template/webpack.config.js
+++ b/packages/create-widget/views/preact/template/webpack.config.js
@@ -7,8 +7,6 @@ const {
   pipe,
 } = require('@merkur/tool-webpack');
 
-createLiveReloadServer();
-
 function applyBabelLoader(config) {
   config.module.rules.push({
     test: /\.(js|jsx)$/,
@@ -24,9 +22,11 @@ function applyBabelLoader(config) {
   return config;
 }
 
-module.exports = Promise.all([
-  pipe(createWebConfig, applyBabelLoader)(),
-  pipe(createWebConfig, applyBabelLoader, applyES5Transformation)(),
-  pipe(createWebConfig, applyBabelLoader, applyES9Transformation)(),
-  pipe(createNodeConfig, applyBabelLoader)(),
-]);
+module.exports = createLiveReloadServer().then(() =>
+  Promise.all([
+    pipe(createWebConfig, applyBabelLoader)(),
+    pipe(createWebConfig, applyBabelLoader, applyES5Transformation)(),
+    pipe(createWebConfig, applyBabelLoader, applyES9Transformation)(),
+    pipe(createNodeConfig, applyBabelLoader)(),
+  ])
+);

--- a/packages/create-widget/views/react/template/webpack.config.js
+++ b/packages/create-widget/views/react/template/webpack.config.js
@@ -7,8 +7,6 @@ const {
   pipe,
 } = require('@merkur/tool-webpack');
 
-createLiveReloadServer();
-
 function applyBabelLoader(config) {
   config.module.rules.push({
     test: /\.(js|jsx)$/,
@@ -24,9 +22,11 @@ function applyBabelLoader(config) {
   return config;
 }
 
-module.exports = Promise.all([
-  pipe(createWebConfig, applyBabelLoader)(),
-  pipe(createWebConfig, applyBabelLoader, applyES5Transformation)(),
-  pipe(createWebConfig, applyBabelLoader, applyES9Transformation)(),
-  pipe(createNodeConfig, applyBabelLoader)(),
-]);
+module.exports = createLiveReloadServer().then(() =>
+  Promise.all([
+    pipe(createWebConfig, applyBabelLoader)(),
+    pipe(createWebConfig, applyBabelLoader, applyES5Transformation)(),
+    pipe(createWebConfig, applyBabelLoader, applyES9Transformation)(),
+    pipe(createNodeConfig, applyBabelLoader)(),
+  ])
+);

--- a/packages/create-widget/views/svelte/template/webpack.config.js
+++ b/packages/create-widget/views/svelte/template/webpack.config.js
@@ -8,8 +8,6 @@ const {
   webpackMode,
 } = require('@merkur/tool-webpack');
 
-createLiveReloadServer();
-
 function applySvelteWeb(config) {
   config.module.rules.push({
     test: /\.(svelte|html)$/,
@@ -49,9 +47,11 @@ function applySvelteNode(config) {
   return config;
 }
 
-module.exports = Promise.all([
-  pipe(createWebConfig, applySvelteWeb)(),
-  pipe(createWebConfig, applySvelteWeb, applyES5Transformation)(),
-  pipe(createWebConfig, applySvelteWeb, applyES9Transformation)(),
-  pipe(createNodeConfig, applySvelteNode)(),
-]);
+module.exports = createLiveReloadServer().then(() =>
+  Promise.all([
+    pipe(createWebConfig, applySvelteWeb)(),
+    pipe(createWebConfig, applySvelteWeb, applyES5Transformation)(),
+    pipe(createWebConfig, applySvelteWeb, applyES9Transformation)(),
+    pipe(createNodeConfig, applySvelteNode)(),
+  ])
+);

--- a/packages/create-widget/views/uhtml/template/webpack.config.js
+++ b/packages/create-widget/views/uhtml/template/webpack.config.js
@@ -7,11 +7,11 @@ const {
   pipe,
 } = require('@merkur/tool-webpack');
 
-createLiveReloadServer();
-
-module.exports = Promise.all([
-  pipe(createWebConfig)(),
-  pipe(createWebConfig, applyES5Transformation)(),
-  pipe(createWebConfig, applyES9Transformation)(),
-  pipe(createNodeConfig)(),
-]);
+module.exports = createLiveReloadServer().then(() =>
+  Promise.all([
+    pipe(createWebConfig)(),
+    pipe(createWebConfig, applyES5Transformation)(),
+    pipe(createWebConfig, applyES9Transformation)(),
+    pipe(createNodeConfig)(),
+  ])
+);

--- a/packages/create-widget/views/vanilla/template/webpack.config.js
+++ b/packages/create-widget/views/vanilla/template/webpack.config.js
@@ -7,11 +7,11 @@ const {
   pipe,
 } = require('@merkur/tool-webpack');
 
-createLiveReloadServer();
-
-module.exports = Promise.all([
-  pipe(createWebConfig)(),
-  pipe(createWebConfig, applyES5Transformation)(),
-  pipe(createWebConfig, applyES9Transformation)(),
-  pipe(createNodeConfig)(),
-]);
+module.exports = createLiveReloadServer().then(() =>
+  Promise.all([
+    pipe(createWebConfig)(),
+    pipe(createWebConfig, applyES5Transformation)(),
+    pipe(createWebConfig, applyES9Transformation)(),
+    pipe(createNodeConfig)(),
+  ])
+);

--- a/packages/tool-webpack/index.cjs
+++ b/packages/tool-webpack/index.cjs
@@ -1,5 +1,6 @@
 const path = require('path');
 const zlib = require('zlib');
+const fp = require('find-free-port');
 const WebpackShellPlugin = require('webpack-shell-plugin-next');
 const nodeExternals = require('webpack-node-externals');
 const WebpackModules = require('webpack-modules');
@@ -89,9 +90,19 @@ function getPlugins(options = {}) {
   return { webPlugins, nodePlugins };
 }
 
-function createLiveReloadServer() {
+async function createLiveReloadServer() {
   if (environment === DEVELOPMENT) {
-    WebSocket.createServer();
+    try {
+      const [freePort] = await fp(4321);
+      process.env.MERKUR_PLAYGROUND_LIVERELOAD_PORT = freePort;
+
+      WebSocket.createServer({
+        port: freePort,
+      });
+    } catch (error) {
+      console.error(error);
+      throw new Error('Unable to retrieve free port for livereload server.');
+    }
   }
 }
 

--- a/packages/tool-webpack/package-lock.json
+++ b/packages/tool-webpack/package-lock.json
@@ -1413,6 +1413,11 @@
 				"pkg-dir": "^4.1.0"
 			}
 		},
+		"find-free-port": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-free-port/-/find-free-port-2.0.0.tgz",
+			"integrity": "sha1-SyLl9leesaOMQaxryz7+0bbamxs="
+		},
 		"find-up": {
 			"version": "4.1.0",
 			"resolved": "https://npm.dev.dszn.cz/find-up/-/find-up-4.1.0.tgz",

--- a/packages/tool-webpack/package.json
+++ b/packages/tool-webpack/package.json
@@ -35,6 +35,7 @@
     "compression-webpack-plugin": "^8.0.1",
     "core-js": "3.16.2",
     "css-loader": "6.2.0",
+    "find-free-port": "^2.0.0",
     "json-loader": "0.5.7",
     "mini-css-extract-plugin": "2.2.0",
     "webpack-bundle-analyzer": "^4.4.2",

--- a/packages/tools/static/livereload.js
+++ b/packages/tools/static/livereload.js
@@ -20,7 +20,7 @@ class WebSocketMerkur {
     /**
      * @type {Object}
      */
-    this._options = Object.assign({ url: 'ws://localhost:4321' }, options);
+    this._options = Object.assign({}, options);
   }
 
   init() {
@@ -124,6 +124,8 @@ class WebSocketMerkur {
 }
 
 window.__merkur_dev__ = window.__merkur_dev__ || {};
+window.__merkur_dev__.webSocketOptions =
+  window.__merkur_dev__.webSocketOptions || {};
 window.__merkur_dev__.webSocket = new WebSocketMerkur(
   window.__merkur_dev__.webSocketOptions
 )

--- a/packages/tools/websocket.cjs
+++ b/packages/tools/websocket.cjs
@@ -2,10 +2,6 @@
 
 const WebSocket = require('ws');
 
-const DEFAULT_OPTIONS = {
-  port: 4321,
-};
-
 function broadcastMessage(server, fromClient, data) {
   server.clients.forEach(function each(toClient) {
     sendMessage(fromClient, toClient, data);
@@ -19,12 +15,16 @@ function sendMessage(fromClient, toClient, data) {
 }
 
 function createServer(options = {}) {
-  options = Object.assign({}, DEFAULT_OPTIONS, options);
+  options = Object.assign(
+    {},
+    { port: process.env.MERKUR_PLAYGROUND_LIVERELOAD_PORT },
+    options
+  );
+
   let server = null;
 
   try {
     server = new WebSocket.Server(options);
-
     server.on('connection', function connection(ws) {
       ws.on('message', function incoming(data, isBinary) {
         data = isBinary ? data : data.toString();
@@ -39,14 +39,16 @@ function createServer(options = {}) {
 }
 
 function createClient(options) {
-  options = Object.assign({}, DEFAULT_OPTIONS, options);
-  const client = new WebSocket('ws://localhost:' + options.port);
+  options = Object.assign(
+    {},
+    { port: process.env.MERKUR_PLAYGROUND_LIVERELOAD_PORT },
+    options
+  );
 
-  return client;
+  return new WebSocket('ws://localhost:' + options.port);
 }
 
 module.exports = {
-  DEFAULT_OPTIONS,
   createServer,
   createClient,
 };


### PR DESCRIPTION
This enables running multiple merkur widgets side by side (as long as
their running on their own ports) without any additional changes with
their own live reload. This also fixes potential issues on devices where
port 4321 is occupied, which would resolve in dev server not running.

BREAKING CHANGE: 🧨 createLiveReloadServer() function must be promise chained in
webpack.config.js before returning any config array.