### PR TITLE
fix: 🐛 correct binding of widget to methods

### DIFF
--- a/packages/plugin-http-client/package-lock.json
+++ b/packages/plugin-http-client/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@merkur/core": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@merkur/core/-/core-0.27.0.tgz",
-      "integrity": "sha512-Ga5w6mU1U3EA8NNcVJ9qVx8mLRpJpJSngG7R3cw4vZ6uHYVYzT0A37B7em7q0MjiPl2tuivGBToUbYof7wMCug==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@merkur/core/-/core-0.27.1.tgz",
+      "integrity": "sha512-oN5CuOhe6b7vwgLiPH0RWjFxE2yzuoSY2MNdBfHFnp61WUBYzQiXEvY3hfs161mZNjRERj9iCnNa7aORzGlJWQ==",
       "dev": true
     },
     "abort-controller": {

--- a/packages/plugin-http-client/src/__tests__/indexSpec.js
+++ b/packages/plugin-http-client/src/__tests__/indexSpec.js
@@ -119,6 +119,7 @@ describe('createWidget method with http client plugin', () => {
         },
         "$plugins": Array [
           Object {
+            "create": [Function],
             "setup": [Function],
           },
         ],

--- a/packages/plugin-http-client/src/index.js
+++ b/packages/plugin-http-client/src/index.js
@@ -38,8 +38,10 @@ export function httpClientPlugin() {
       widget.$dependencies.fetch = getFetchAPI();
       widget.$dependencies.AbortController = AbortController;
 
+      return widget;
+    },
+    async create(widget) {
       bindWidgetToFunctions(widget, widget.http);
-
       return widget;
     },
   };


### PR DESCRIPTION
Fixed binding of widget object to http-client plugin methods so that `request`
method and subsequently all transformers receive "complete" widget
object after it has passed through all plugins and all `setup` methods.