### PR TITLE
fix: 🐛 error message missing status in http2

### DIFF
--- a/packages/plugin-http-client/src/index.js
+++ b/packages/plugin-http-client/src/index.js
@@ -73,9 +73,12 @@ function httpClientAPI() {
         );
 
         if (!response.ok) {
-          const error = new Error(`${response.statusText}: ${request.url}`, {
-            cause: { request, response },
-          });
+          const error = new Error(
+            `Received ${response.status} status code when requesting ${request.url}`,
+            {
+              cause: { request, response },
+            },
+          );
           // keep compatablity
           error.request = request;
           error.response = response;


### PR DESCRIPTION
[In HTTP2, statusText is empty](https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText#value). This results in half of the error message missing. I wanted to make the err message more readable, but if this is not preferred I can simplify it, perhaps to `Status code ${response.status}: ${request.url}`?

