### PR TITLE
feat: 🎸 custom element attributes are propagated as widget prop

### DIFF
--- a/docs/docs/register-custom-element.md
+++ b/docs/docs/register-custom-element.md
@@ -5,27 +5,27 @@ title: Register Merkur widget as custom element
 
 # Register Merkur widget as custom element
 
-Merkur widget can be registered as custom element. It is helpful for use case where SSR is not important for Merkur widget. We predict that you serve your widget as single JavaScript file with defined assets.
+Merkur widgets can be registered as custom elements. This is useful for cases where SSR is not required. We assume that your widget is served as a single JavaScript file with defined assets.
 
 ## Installation
 
-For easy registration Merkur widget as custom element we created the `@merkur/integration-custom-element` module. The module is designed for only client-side.
+To easily register a Merkur widget as a custom element, use the `@merkur/integration-custom-element` module. This module is designed for client-side usage only.
 
 ```bash
 npm i @merkur/integration-custom-element --save
 ```
 
-## How to change default Merkur template
+## How to modify the default Merkur template
 
-The default Merkur template is prepared for SSR so we will remove in below sections useless parts and files to reconfigure default template to only client template. At first you should create new Merkur widget is described in [Getting started](https://merkur.js.org/docs/getting-started).
+The default Merkur template is prepared for SSR. In the following sections, we will remove unnecessary parts and files to reconfigure the template for client-side usage only. First, create a new Merkur widget as described in [Getting started](https://merkur.js.org/docs/getting-started).
 
 ### Server part
 
-After created new Merkur widget you change your playground template for creating `/server/playground/templates/body.ejs` and `/server/playground/templates/footer.ejs` files or run `merkur custom playground:body` and `merkur custom playground:footer`. Then after creating files in your project change files to:
+After creating a new Merkur widget, update your playground template by creating the `/server/playground/templates/body.ejs` and `/server/playground/templates/footer.ejs` files. You can also run `merkur custom playground:body` and `merkur custom playground:footer` to generate these files. Then, modify the files as follows:
 
 ```javascript
 // body.ejs
-<{package.name}></{package-name}> // something like <merkur-widget></merkur-widget>
+<{package.name}></{package-name}> // e.g., <merkur-widget></merkur-widget>
 ```
 
 ```javascript
@@ -33,11 +33,11 @@ After created new Merkur widget you change your playground template for creating
 // keep empty
 ```
 
-We changed logic for reviveling widget in playground and added only custom element with name from `package.json` to the body part of html. The custom element auto revive Merkur widget. Now you can remove other files in `/server/*` folder. 
+This changes the logic for reviving the widget in the playground by adding only the custom element with the name from `package.json` to the body of the HTML. The custom element will automatically revive the Merkur widget. You can now remove other files in the `/server/*` folder.
 
-### CLI config
+### CLI configuration
 
-You can change `merkur.config.mjs` file to add `@merkur/integration-custom-element/cli` to extends field.
+Update the `merkur.config.mjs` file to include `@merkur/integration-custom-element/cli` in the `extends` field.
 
 ```javascript
 /**
@@ -45,18 +45,25 @@ You can change `merkur.config.mjs` file to add `@merkur/integration-custom-eleme
  */
 export default function () {
   return {
-    extends: ['@merkur/preact/cli' ,'@merkur/integration-custom-element/cli'],
+    extends: ['@merkur/preact/cli', '@merkur/integration-custom-element/cli'],
   };
 }
 ```
 
-The `@merkur/integration-custom-element/cli` modify default `@merkur/cli` configuration (change playground widgetHandler to skip `/widget` request, turn off widget server because custom element works only in browser, turn off HMR and use hot reload instead, filter node platform tasks, force generated files to be saved to filesystem as writeToDisk = true, register css bundle plugin for including bundled css file to js).
+The `@merkur/integration-custom-element/cli` modifies the default `@merkur/cli` configuration by:
+- Skipping `/widget` requests in the playground widget handler.
+- Disabling the widget server (custom elements work only in the browser).
+- Turning off HMR and enabling hot reload instead.
+- Filtering out tasks for the Node.js platform.
+- Forcing generated files to be saved to the filesystem (`writeToDisk = true`).
+- Registering a CSS bundle plugin to include bundled CSS files in the JavaScript.
 
 ### Widget part
 
-The default Merkur template use `config` npm module for resolving application environment. But `config` module doesn't work in browser so we must add support for application environment to our client solution with custom element.
+The default Merkur template uses the `config` npm module for resolving the application environment. However, the `config` module does not work in the browser. To address this, add support for application environments in the client solution with custom elements.
 
-Create new `config` folder in `/src/` and then there create new file `/src/config/index.js` where copy paste code below which add support for two environments `development` and `production`. The `development` environment extends `production` environment. So you don't need copy all options. The webpack tree shaking logic helps removed `development` environment in `production` build.
+1. Create a new `config` folder in `/src/`.
+2. Inside the `config` folder, create a file `/src/config/index.js` with the following code:
 
 ```javascript
 import { deepMerge } from '@merkur/integration-custom-element';
@@ -74,7 +81,7 @@ if (process.env.NODE_ENV === 'production') {
 export { environment };
 ```
 
-Now you can create your own `production` and `development` environments in `/src/config/production.js` and `/src/config/development.js` files. For example `/src/config/production.js` file:
+3. Create `production` and `development` environment files in `/src/config/production.js` and `/src/config/development.js`. For example, `/src/config/production.js`:
 
 ```javascript
 export default {
@@ -86,65 +93,117 @@ export default {
 };
 ```
 
-We add our resolved environment to widget `props.environment` property in `/src/widget.js`. Same as it works in default Merkur template. The custom element don't support Merkur slots. So we set `slotFactories` to empty array. Then you can remove `src/components/slots` folder. If you want to inline css bundle to resulted JS file then add `import cssBundle from '@merkur/integration-custom-element/cssBundle'` and define `inlineStyle` asset with cssBundle as source. At the end register your widget as custom element with `registerCustomElement` method which alive widget and connect widget with custom element. 
+4. Add the resolved environment to the widget's `props.environment` property in `/src/widget.js`. Since custom elements do not support Merkur slots, set `slotFactories` to an empty array. You can also remove the `src/components/slots` folder.
+
+5. To inline the CSS bundle into the resulting JS file, add the following import and define an `inlineStyle` asset:
 
 ```javascript
-/* eslint-disable no-unused-vars */
-import { defineWidget } from '@merkur/core';
-import {
-  componentPlugin,
-  createViewFactory,
-  createSlotFactory,
-} from '@merkur/plugin-component';
-import { errorPlugin } from '@merkur/plugin-error';
-import { eventEmitterPlugin } from '@merkur/plugin-event-emitter';
-import { registerCustomElement } from '@merkur/integration-custom-element';
-
-import { environment } from './config';
-import View from './views/View';
-
-import { name, version } from '../package.json';
-
-import './style.css';
-
 import cssBundle from '@merkur/integration-custom-element/cssBundle';
 
-const widgetDefinition = defineWidget({
-  name,
-  version,
-  viewFactory: createViewFactory((widget) => ({
-    View,
-    slotFactories: [],
-  })),
-  props: {
-    environment,
+assets: [
+  {
+    name: 'widget.css',
+    type: 'inlineStyle',
+    source: cssBundle,
   },
-  $plugins: [componentPlugin, eventEmitterPlugin, errorPlugin],
-  assets: [
-    {
-      name: 'widget.css',
-      type: 'inlineStyle',
-      source: cssBundle,
-    },
-  ],
-  onClick(widget) {
-    widget.setState({ counter: widget.state.counter + 1 });
-  },
-  onReset(widget) {
-    widget.setState({ counter: 0 });
-  },
-  load(widget) {
-    // We don't want to set environment into app state
-    const { environment, ...restProps } = widget.props;
+],
+```
 
-    return {
-      counter: 0,
-      ...restProps,
-    };
-  },
-});
+6. Finally, register your widget as a custom element using the `registerCustomElement` method:
 
-export default widgetDefinition;
+```javascript
+import { registerCustomElement } from '@merkur/integration-custom-element';
+
+// ...existing code...
 
 registerCustomElement({ widgetDefinition });
 ```
+
+### Callbacks
+
+The `registerCustomElement` method accepts a `callbacks` object that allows you to hook into the lifecycle of the custom element. These callbacks include:
+
+- `constructor`: Called when the custom element is created.
+- `connectedCallback`: Called when the custom element is added to the DOM.
+- `disconnectedCallback`: Called when the custom element is removed from the DOM.
+- `adoptedCallback`: Called when the custom element is moved to a new document.
+- `attributeChangedCallback`: Called when an observed attribute changes.
+- `mount`: Called when the widget is mounted.
+- `remount`: Called when the widget is remounted.
+- `getInstance`: Called to retrieve an existing widget instance.
+
+Each callback receives the widget instance, the shadow DOM, and the custom element as arguments.
+
+#### Example
+
+Here is an example of how to use the `callbacks` object:
+
+```javascript
+import { registerCustomElement } from '@merkur/integration-custom-element';
+import widgetDefinition from './widget';
+
+registerCustomElement({
+  widgetDefinition,
+  callbacks: {
+    constructor(widget, { shadow, customElement }) {
+      console.log('Custom element created:', customElement);
+    },
+    connectedCallback(widget, { shadow, customElement }) {
+      console.log('Custom element added to DOM:', customElement);
+    },
+    disconnectedCallback(widget, { shadow, customElement }) {
+      console.log('Custom element removed from DOM:', customElement);
+    },
+    adoptedCallback(widget, { shadow, customElement }) {
+      console.log('Custom element moved to a new document:', customElement);
+    },
+    attributeChangedCallback(widget, name, oldValue, newValue, { shadow, customElement }) {
+      console.log(`Attribute "${name}" changed from "${oldValue}" to "${newValue}"`);
+    },
+    mount(widget, { shadow, customElement }) {
+      console.log('Widget mounted:', widget);
+    },
+    remount(widget, { shadow, customElement }) {
+      console.log('Widget remounted:', widget);
+    },
+    getInstance() {
+      console.log('Retrieving existing widget instance');
+      return null; // Return an existing widget instance if available
+    },
+  },
+});
+```
+
+This example demonstrates how to log messages during each lifecycle event of the custom element. You can replace the `console.log` statements with your own logic to handle these events.
+
+### `widget.root` and `widget.customElement`
+
+- `widget.root`: Refers to the root DOM node where the widget is rendered. For custom elements, this is typically the shadow DOM of the element.
+- `widget.customElement`: Refers to the custom element instance itself. This allows you to interact with the custom element directly from the widget.
+
+These properties are automatically set when the widget is registered as a custom element and can be used to manage the widget's lifecycle or interact with the DOM.
+
+### Default propagation of attributes to widget props
+
+When a custom element is registered, its attributes are automatically propagated to the widget's `props` object. This allows you to configure the widget directly through the custom element's attributes in the HTML.
+
+#### How it works
+
+1. The `observedAttributes` property in the `registerCustomElement` options specifies which attributes the custom element observes. These attributes are automatically monitored for changes.
+2. When an observed attribute changes, the `attributeChangedCallback` is triggered. This callback updates the corresponding property in the widget's `props` object.
+
+#### Example
+
+```javascript
+import { registerCustomElement } from '@merkur/integration-custom-element';
+import widgetDefinition from './widget';
+
+registerCustomElement({
+  widgetDefinition,
+  observedAttributes: ['title', 'theme'], // Attributes to observe
+});
+```
+
+In this example:
+- The `observedAttributes` property specifies the attributes to observe (`title` and `theme`).
+- The widget's `props` are automatically updated when the observed attributes change.

--- a/docs/docs/register-custom-element.md
+++ b/docs/docs/register-custom-element.md
@@ -185,12 +185,14 @@ These properties are automatically set when the widget is registered as a custom
 
 ### Default propagation of attributes to widget props
 
-When a custom element is registered, its attributes are automatically propagated to the widget's `props` object. This allows you to configure the widget directly through the custom element's attributes in the HTML.
+When a custom element is registered, its attributes are automatically propagated to the widget's `props` object.
 
 #### How it works
 
 1. The `observedAttributes` property in the `registerCustomElement` options specifies which attributes the custom element observes. These attributes are automatically monitored for changes.
 2. When an observed attribute changes, the `attributeChangedCallback` is triggered. This callback updates the corresponding property in the widget's `props` object.
+3. Attribute names are automatically converted to camelCase.
+4. The `attributesParser` function can be used to customize how attributes are processed. For example, you can parse specific attributes like JSON strings.
 
 #### Example
 
@@ -200,10 +202,15 @@ import widgetDefinition from './widget';
 
 registerCustomElement({
   widgetDefinition,
-  observedAttributes: ['title', 'theme'], // Attributes to observe
+  observedAttributes: ['title', 'theme', 'long-name', 'config'], // Attributes to observe
+  attributesParser: {
+    config: (value) => JSON.parse(value); 
+  }
 });
 ```
 
 In this example:
-- The `observedAttributes` property specifies the attributes to observe (`title` and `theme`).
+- The `observedAttributes` property specifies the attributes to observe (`title`, `theme`, `long-name` and `config`).
 - The widget's `props` are automatically updated when the observed attributes change.
+- The `config` attribute is parsed from a JSON string into an object.
+- The `long-name` attribute is automatically transformed into `longName` in the widget's `props`.

--- a/packages/integration-custom-element/src/__tests__/indexSpec.js
+++ b/packages/integration-custom-element/src/__tests__/indexSpec.js
@@ -26,6 +26,11 @@ describe('Merkur integration custom element', () => {
           d: ['3', '4', '7'],
         },
       });
+
+      // let clonedTarget = deepMerge({}, target);
+      // let deepTarget = deepMerge({}, target);
+      // deepTarget.a = 2;
+      // expect(target.a !== deepTarget.a).toEqual(true);
     });
   });
 

--- a/packages/integration-custom-element/src/__tests__/indexSpec.js
+++ b/packages/integration-custom-element/src/__tests__/indexSpec.js
@@ -1,4 +1,4 @@
-import { deepMerge } from '..';
+import { deepMerge, registerCustomElement } from '../index';
 
 describe('Merkur integration custom element', () => {
   describe('deepMerge method', () => {
@@ -29,367 +29,72 @@ describe('Merkur integration custom element', () => {
     });
   });
 
-  it('should create other test', () => {
-    expect(true).toBeTruthy();
+  describe('registerCustomElement method', () => {
+    const callbacks = {
+      constructor: jest.fn(),
+      connectedCallback: jest.fn(),
+      disconnectedCallback: jest.fn(),
+      adoptedCallback: jest.fn(),
+      attributeChangedCallback: jest.fn(),
+    };
+
+    const widgetDefinition = {
+      name: 'merkur-test',
+      version: '1.0.0',
+      assets: [],
+      props: {
+        name: 'John',
+      },
+      createWidget: () => {
+        return widgetDefinition;
+      },
+
+      setProps: jest.fn(),
+      mount: jest.fn(),
+      unmount: jest.fn(),
+      update: jest.fn(),
+
+      attributeChangedCallback: jest.fn(),
+    };
+
+    const observedAttributes = ['name'];
+
+    let WidgetElement = registerCustomElement({
+      widgetDefinition,
+      observedAttributes,
+      callbacks,
+    });
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should call constructor, connectedCallback and mount methods after widget is created', async () => {
+      const widgetElement = new WidgetElement();
+      widgetElement.connectedCallback(); // simulate browser
+
+      await widgetElement._widgetPromise;
+
+      expect(widgetElement._widget.props.name).toBe('John');
+      expect(widgetDefinition.mount).toHaveBeenCalledTimes(1);
+      expect(callbacks.constructor).toHaveBeenCalledTimes(1);
+      expect(callbacks.connectedCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call attributeChangedCallback when attributes change', async () => {
+      const widgetElement = new WidgetElement();
+      widgetElement.connectedCallback(); // simulate browser
+
+      await widgetElement._widgetPromise;
+
+      await widgetElement.attributeChangedCallback('name', 'John', 'Jane');
+
+      expect(callbacks.attributeChangedCallback).toHaveBeenCalledTimes(1);
+      expect(widgetDefinition.attributeChangedCallback).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(widgetDefinition.setProps).toHaveBeenCalledWith({
+        name: 'Jane',
+      });
+    });
   });
 });
-
-// import { loadStyleAssets, loadScriptAssets } from '../index';
-
-// global.console.warn = jest.fn();
-
-// describe('Merkur component', () => {
-//   let assets = [];
-//   let fakeAssetObjects = [];
-//   let rootElement = null;
-
-//   const fakeAssetObjectGenerator = () => {
-//     const fakeAssetObject = {
-//       onerror: jest.fn(),
-//       onload: jest.fn(),
-//       removeAttribute: (name) => delete fakeAssetObject[name],
-//       setAttribute: (name, value) => (fakeAssetObject[name] = value),
-//       addEventListener: jest.fn((type, callback) => callback(type)),
-//       src: 'http://localhost:4444/static/es9/test.6961af42bfa3596bb147.js',
-//       remove: jest.fn(),
-//     };
-//     fakeAssetObjects.push(fakeAssetObject);
-
-//     return fakeAssetObject;
-//   };
-
-//   const resolveFakeAssets = () => {
-//     for (const fakeAsset of fakeAssetObjects) {
-//       fakeAsset.onload();
-//     }
-//   };
-
-//   const rejectFakeAssets = () => {
-//     for (const fakeAsset of fakeAssetObjects) {
-//       fakeAsset.onerror();
-//     }
-//   };
-
-//   beforeEach(() => {
-//     assets = [
-//       {
-//         name: 'widget.js',
-//         type: 'script',
-//         source: {
-//           es11: 'http://localhost:4444/static/es11/widget.6541af42bfa3596bb129.js',
-//           es9: 'http://localhost:4444/static/es9/widget.6961af42bfa3596bb147.js',
-//         },
-//         attr: {
-//           async: true,
-//           'custom-element': 'amp-fx-collection',
-//           defer: false,
-//         },
-//       },
-//       {
-//         name: 'polyfill1.js',
-//         test: 'return typeof window !== "undefined"',
-//         type: 'script',
-//         source: {
-//           es11: 'http://localhost:4444/static/es11/polyfill.6961af42bfa3596bb147.js',
-//           es9: 'http://localhost:4444/static/es9/polyfill.6961af42bfa3596bb147.js',
-//         },
-//       },
-//       {
-//         name: 'undefined.js',
-//         type: 'script',
-//         source: {
-//           es11: undefined,
-//           es9: 'http://localhost:4444/static/es9/undefined.6961af42bfa3596bb147.js',
-//         },
-//       },
-//       {
-//         name: 'polyfill2.js',
-//         test: 'return (function () {foo();})()',
-//         type: 'script',
-//         source:
-//           'http://localhost:4444/static/es9/polyfill.6961af42bfa3596bb147.js',
-//       },
-//       {
-//         type: 'inlineScript',
-//         source: 'alert();',
-//       },
-//       {
-//         name: 'widget.css',
-//         type: 'stylesheet',
-//         source:
-//           'http://localhost:4444/static/es11/widget.814e0cb568c7ddc0725d.css',
-//       },
-//       {
-//         type: 'inlineStyle',
-//         source: '.cssClass { margin-top: 5px; }',
-//       },
-//     ];
-
-//     fakeAssetObjects = [];
-
-//     jest
-//       .spyOn(document, 'createElement')
-//       .mockImplementation(fakeAssetObjectGenerator);
-//     jest.spyOn(document.head, 'appendChild').mockImplementation();
-
-//     rootElement = {
-//       querySelectorAll: jest.fn(() => []),
-//       querySelector: jest.fn(() => null),
-//       appendChild: jest.fn(),
-//     };
-//   });
-
-//   afterEach(() => {
-//     jest.restoreAllMocks();
-//   });
-
-//   describe('loadStyleAssets() function', () => {
-//     it('should create style elements for style assets', (done) => {
-//       loadStyleAssets(assets)
-//         .then(() => {
-//           expect(document.createElement).toHaveBeenCalledTimes(2);
-//           expect(document.createElement).toHaveBeenNthCalledWith(1, 'link');
-//           expect(document.createElement).toHaveBeenNthCalledWith(2, 'style');
-//           expect(document.head.appendChild).toHaveBeenCalledTimes(2);
-
-//           done();
-//         })
-//         .catch(done);
-
-//       resolveFakeAssets();
-
-//       expect(fakeAssetObjects).toMatchSnapshot();
-//     });
-
-//     it('should return promise that resolves after the styles are loaded', (done) => {
-//       const stylePromise = loadStyleAssets(assets)
-//         .then(() => {
-//           expect(stylePromise).toBeInstanceOf(Promise);
-
-//           done();
-//         })
-//         .catch(done);
-
-//       resolveFakeAssets();
-//     });
-
-//     it('should append style assets to specified element', (done) => {
-//       loadStyleAssets(assets, rootElement)
-//         .then(() => {
-//           expect(rootElement.appendChild).toHaveBeenCalledTimes(2);
-//           done();
-//         })
-//         .catch(done);
-
-//       resolveFakeAssets();
-//     });
-//   });
-
-//   describe('loadScriptAssets() function', () => {
-//     it('should create script elements for script assets', (done) => {
-//       loadScriptAssets(assets)
-//         .then(() => {
-//           expect(document.createElement).toHaveBeenCalledTimes(4);
-//           expect(document.head.appendChild).toHaveBeenCalledTimes(4);
-
-//           done();
-//         })
-//         .catch(done);
-
-//       resolveFakeAssets();
-
-//       expect(fakeAssetObjects).toMatchSnapshot();
-//     });
-
-//     it('should return promise that resolves after the scripts are loaded', (done) => {
-//       const scriptsPromise = loadScriptAssets(assets)
-//         .then(() => {
-//           expect(scriptsPromise).toBeInstanceOf(Promise);
-
-//           done();
-//         })
-//         .catch(done);
-
-//       resolveFakeAssets();
-//     });
-
-//     it('should append script assets to specified element', (done) => {
-//       loadScriptAssets(assets, rootElement)
-//         .then(() => {
-//           expect(document.createElement).toHaveBeenCalledTimes(4);
-//           expect(rootElement.appendChild).toHaveBeenCalledTimes(4);
-
-//           done();
-//         })
-//         .catch(done);
-
-//       resolveFakeAssets();
-//     });
-
-//     it('should return promise that rejects after script fails to load', (done) => {
-//       let script;
-//       jest.spyOn(rootElement, 'appendChild').mockImplementation((child) => {
-//         script = child;
-//       });
-//       loadScriptAssets(
-//         [
-//           {
-//             name: 'test.js',
-//             type: 'script',
-//             source: {
-//               es9: 'http://localhost:4444/static/es9/test.6961af42bfa3596bb147.js',
-//             },
-//           },
-//         ],
-//         rootElement,
-//       )
-//         .then(() => {
-//           done('promise was resolved');
-//         })
-//         .catch(() => {
-//           expect(document.createElement).toHaveBeenCalledTimes(1);
-//           expect(rootElement.appendChild).toHaveBeenCalledTimes(1);
-//           expect(script.remove).toHaveBeenCalledTimes(1);
-//           done();
-//         });
-
-//       rejectFakeAssets();
-//     });
-
-//     it('should return promise that resolves after script fails to load', (done) => {
-//       let script;
-//       jest.spyOn(rootElement, 'appendChild').mockImplementation((child) => {
-//         script = child;
-//       });
-//       loadScriptAssets(
-//         [
-//           {
-//             name: 'test.js',
-//             type: 'script',
-//             source: {
-//               es9: 'http://localhost:4444/static/es9/test.6961af42bfa3596bb147.js',
-//             },
-//             optional: true,
-//           },
-//         ],
-//         rootElement,
-//       )
-//         .then(() => {
-//           expect(document.createElement).toHaveBeenCalledTimes(1);
-//           expect(rootElement.appendChild).toHaveBeenCalledTimes(1);
-//           expect(script.remove).toHaveBeenCalledTimes(1);
-//           done();
-//         })
-//         .catch(() => {
-//           done('promise was rejected');
-//         });
-
-//       rejectFakeAssets();
-//     });
-
-//     it('should return promise that resolves after existing script loads', (done) => {
-//       const fakeAssetObject = fakeAssetObjectGenerator();
-//       jest
-//         .spyOn(rootElement, 'querySelector')
-//         .mockImplementationOnce(() => fakeAssetObject);
-//       performance.getEntriesByName = jest.fn(() => []);
-
-//       loadScriptAssets(
-//         [
-//           {
-//             name: 'test.js',
-//             type: 'script',
-//             optional: true,
-//             source: {
-//               es9: 'http://localhost:4444/static/es9/test.6961af42bfa3596bb147.js',
-//             },
-//           },
-//         ],
-//         rootElement,
-//       )
-//         .then(() => {
-//           expect(fakeAssetObject.addEventListener).toHaveBeenCalledWith(
-//             'load',
-//             expect.any(Function),
-//           );
-//           expect(fakeAssetObject.addEventListener).toHaveBeenCalledWith(
-//             'error',
-//             expect.any(Function),
-//           );
-//           expect(fakeAssetObject.addEventListener).toHaveBeenCalledTimes(2);
-//           expect(document.createElement).toHaveBeenCalledTimes(0);
-
-//           done();
-//         })
-//         .catch((e) => {
-//           console.error(e);
-//           done('promise was rejected');
-//         });
-//     });
-
-//     it('should throw an error, if script have no source', (done) => {
-//       loadScriptAssets(
-//         [
-//           {
-//             name: 'optional.js',
-//             type: 'script',
-//             source: {},
-//             optional: true,
-//           },
-//           {
-//             name: 'nosource.js',
-//             type: 'script',
-//             source: {},
-//           },
-//         ],
-//         rootElement,
-//       )
-//         .then(() => {
-//           done('did not reject');
-//         })
-//         .catch((error) => {
-//           expect(error.message).toBe(
-//             "Asset 'nosource.js' is missing ES variant and could not be loaded.",
-//           );
-//           expect(error.asset).toBeTruthy();
-
-//           done();
-//         });
-//     });
-
-//     it('should resolve if script is already present in DOM and loaded', (done) => {
-//       jest
-//         .spyOn(rootElement, 'querySelector')
-//         .mockImplementation(() => 'truthy');
-
-//       loadScriptAssets(
-//         [
-//           {
-//             name: 'test.js',
-//             type: 'script',
-//             source: {
-//               es11: 'http://localhost:4444/static/es11/test.6961af42bfa3596bb147.js',
-//             },
-//             test: 'return true',
-//           },
-//           {
-//             name: 'test2.js',
-//             type: 'script',
-//             source: {
-//               es11: 'http://localhost:4444/static/es11/test.6961af42bfa3596bb147.js',
-//             },
-//           },
-//         ],
-//         rootElement,
-//       )
-//         .then(() => {
-//           expect(document.createElement).toHaveBeenCalledTimes(0);
-
-//           done();
-//         })
-//         .catch((error) => {
-//           done(error);
-//         });
-//     });
-//   });
-// });

--- a/packages/integration-custom-element/src/__tests__/indexSpec.js
+++ b/packages/integration-custom-element/src/__tests__/indexSpec.js
@@ -49,6 +49,10 @@ describe('Merkur integration custom element', () => {
       assets: [],
       props: {
         name: 'John',
+        multiName: ['John', 'Doe'],
+        config: {
+          key: 'value',
+        },
       },
       createWidget: () => {
         return widgetDefinition;
@@ -63,10 +67,20 @@ describe('Merkur integration custom element', () => {
     };
 
     const observedAttributes = ['name'];
+    const attributesParser = {
+      config: (value) => {
+        try {
+          return JSON.parse(value);
+        } catch (e) {
+          return null;
+        }
+      },
+    };
 
     let WidgetElement = registerCustomElement({
       widgetDefinition,
       observedAttributes,
+      attributesParser,
       callbacks,
     });
     beforeEach(() => {
@@ -92,13 +106,29 @@ describe('Merkur integration custom element', () => {
       await widgetElement._widgetPromise;
 
       await widgetElement.attributeChangedCallback('name', 'John', 'Jane');
+      await widgetElement.attributeChangedCallback(
+        'multi-name',
+        'John Doe',
+        'Jane Doe',
+      );
+      await widgetElement.attributeChangedCallback(
+        'config',
+        '{"key": "value"}',
+        '{"key": "newValue"}',
+      );
 
-      expect(callbacks.attributeChangedCallback).toHaveBeenCalledTimes(1);
+      expect(callbacks.attributeChangedCallback).toHaveBeenCalledTimes(3);
       expect(widgetDefinition.attributeChangedCallback).toHaveBeenCalledTimes(
-        1,
+        3,
       );
       expect(widgetDefinition.setProps).toHaveBeenCalledWith({
         name: 'Jane',
+      });
+      expect(widgetDefinition.setProps).toHaveBeenCalledWith({
+        multiName: 'Jane Doe',
+      });
+      expect(widgetDefinition.setProps).toHaveBeenCalledWith({
+        config: { key: 'newValue' },
       });
     });
   });

--- a/packages/integration-custom-element/src/index.js
+++ b/packages/integration-custom-element/src/index.js
@@ -179,7 +179,7 @@ function registerCustomElement(options) {
     async attributeChangedCallback(name, oldValue, newValue) {
       await this._widgetPromise;
 
-      this._widget.setProps({ name: newValue });
+      this._widget?.setProps?.({ name: newValue });
 
       this._widget?.attributeChangedCallback?.(
         this._widget,
@@ -206,7 +206,10 @@ function registerCustomElement(options) {
 
     _setDefaultProps() {
       const attributes = this.constructor.observedAttributes;
-      if (Array.isArray(attributes)) {
+      if (
+        Array.isArray(attributes) &&
+        typeof this._widget.setProps === 'function'
+      ) {
         attributes.forEach((key) => {
           if (this.hasAttribute(key)) {
             this._widget.props[key] =

--- a/packages/integration-custom-element/src/index.js
+++ b/packages/integration-custom-element/src/index.js
@@ -210,6 +210,7 @@ function registerCustomElement(options) {
         Array.isArray(attributes) &&
         typeof this._widget.setProps === 'function'
       ) {
+        this._widget.props = { ...this._widget.props };
         attributes.forEach((key) => {
           if (this.hasAttribute(key)) {
             this._widget.props[key] =

--- a/packages/integration-custom-element/src/index.js
+++ b/packages/integration-custom-element/src/index.js
@@ -69,6 +69,8 @@ function registerCustomElement(options) {
               await afterDOMLoad();
               await loadAssets(widget.assets, this._shadow);
 
+              this._setDefaultProps();
+
               await callbacks?.reconstructor?.(this._widget, {
                 shadow: this._shadow,
                 customElement: this,
@@ -111,6 +113,8 @@ function registerCustomElement(options) {
               customWidgetDefinition,
               this._shadow,
             );
+
+            this._setDefaultProps();
 
             await callbacks?.constructor?.(this._widget, {
               shadow: this._shadow,
@@ -175,6 +179,8 @@ function registerCustomElement(options) {
     async attributeChangedCallback(name, oldValue, newValue) {
       await this._widgetPromise;
 
+      this._widget.setProps({ name: newValue });
+
       this._widget?.attributeChangedCallback?.(
         this._widget,
         name,
@@ -197,11 +203,25 @@ function registerCustomElement(options) {
         },
       );
     }
+
+    _setDefaultProps() {
+      const attributes = this.constructor.observedAttributes;
+      if (Array.isArray(attributes)) {
+        attributes.forEach((key) => {
+          if (this.hasAttribute(key)) {
+            this._widget.props[key] =
+              this.getAttribute(key) ?? this._widget.props[key];
+          }
+        });
+      }
+    }
   }
 
   if (customElements.get(widgetDefinition.name) === undefined) {
     customElements.define(widgetDefinition.name, WidgetElement);
   }
+
+  return WidgetElement;
 }
 
 const PROTECTED_FIELDS = ['__proto__', 'prototype', 'constructor'];


### PR DESCRIPTION
BREAKING CHANGE: 🧨 We changing default behaviour which current do nothing but was possible implemented it with callbacks. We repeated code with propagating custom element attributes to widget.props in several widgets. So propagating is now default and it looks that is usefull.