### PR TITLE
Event callback widget param type

### DIFF
--- a/.changeset/hungry-dingos-report.md
+++ b/.changeset/hungry-dingos-report.md
@@ -1,0 +1,9 @@
+---
+"@merkur/plugin-event-emitter": patch
+---
+
+Correct widget interface
+
+- **What?** Change the type of the `widget` param of the event callback function from `WidgetInternal` to `Widget`.
+- **Why?** `Widget` is what's passed in - its methods are already bound, i.e. don't expect `widget` as the first prop.  
+- **How?** Nothing.

--- a/packages/plugin-event-emitter/types.d.ts
+++ b/packages/plugin-event-emitter/types.d.ts
@@ -1,4 +1,8 @@
-import { type WidgetFunction, type WidgetPlugin } from '@merkur/core';
+import {
+  type Widget,
+  type WidgetFunction,
+  type WidgetPlugin,
+} from '@merkur/core';
 
 export declare function eventEmitterPlugin(): WidgetPlugin;
 
@@ -16,12 +20,12 @@ declare module '@merkur/core' {
     on: (
       widget: WidgetPartial,
       eventName: string,
-      callback: (widget: WidgetPartial, ...args: any[]) => any,
+      callback: (widget: Widget, ...args: any[]) => any,
     ) => ReturnType<WidgetFunction>;
     off: (
       widget: WidgetPartial,
       eventName: string,
-      callback: (widget: WidgetPartial, ...args: any[]) => any,
+      callback: (widget: Widget, ...args: any[]) => any,
     ) => ReturnType<WidgetFunction>;
     emit: (
       widget: WidgetPartial,


### PR DESCRIPTION
The `widget` param in the callback is `Widget`, not `WidgetPartial`. The difference is that its methods are bound, i.e. they don't expect `widget` as the first param. 