### PR TITLE
feat(@merkur/plugin-http-client)!: normalize headers to Headers insta…

### DIFF
--- a/.changeset/http-client-headers-normalization.md
+++ b/.changeset/http-client-headers-normalization.md
@@ -1,0 +1,65 @@
+---
+"@merkur/plugin-http-client": major
+---
+
+**Breaking changes in `@merkur/plugin-http-client`**
+
+### `request.headers` is now always a `Headers` instance
+
+A new built-in `transformHeaders` transformer has been added as the first step in the default transformer pipeline. It normalizes `request.headers` to a [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) instance for every request.
+
+**Migration:** Custom transformers that read or write `request.headers` using plain object access (e.g. `request.headers['Content-Type']` or `{ ...request.headers, ... }`) must be updated to use the `Headers` API:
+
+```js
+// Before
+async transformRequest(widget, request, response) {
+  return [{ ...request, headers: { ...request.headers, Authorization: `Bearer ${token}` } }, response];
+}
+
+// After
+async transformRequest(widget, request, response) {
+  const headers = new Headers(request.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  return [{ ...request, headers }, response];
+}
+```
+
+### `getDefaultTransformers` now returns four transformers
+
+`transformHeaders` is now the first entry in the array returned by `getDefaultTransformers()`. Code that relied on the exact length or index positions of the default transformer array must be updated.
+
+If you supply a custom `transformers` array via `setDefaultConfig` **without** spreading `getDefaultTransformers()`, you must add `transformHeaders()` manually as the first transformer to ensure `request.headers` is always a `Headers` instance:
+
+```js
+import { setDefaultConfig, transformHeaders, transformBody, transformQuery, transformTimeout } from '@merkur/plugin-http-client';
+
+// Before — custom pipeline without getDefaultTransformers
+setDefaultConfig(widget, {
+  transformers: [transformBody(), transformQuery(), transformTimeout(), myTransformer()],
+});
+
+// After — add transformHeaders as the first entry
+setDefaultConfig(widget, {
+  transformers: [transformHeaders(), transformBody(), transformQuery(), transformTimeout(), myTransformer()],
+});
+```
+
+### Default `Content-Type: application/json` for body requests
+
+`transformBody` now automatically sets `Content-Type: application/json` on requests that carry a `body` and use a method other than `GET` or `HEAD`, when no `Content-Type` header is already present. Previously, the header had to be set explicitly.
+
+**Migration:** If you were sending a body with a non-JSON content type and relying on the absence of a default `Content-Type`, you must now explicitly set your desired `Content-Type` header:
+
+```js
+// Explicitly set a non-JSON content type to override the default
+await widget.http.request({
+  method: 'POST',
+  path: '/upload',
+  headers: { 'Content-Type': 'multipart/form-data' },
+  body: formData,
+});
+```
+
+### Polyfill required for build targets below ES2017 (ES8)
+
+The `Headers` global (part of the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Headers)) is used at runtime by `transformHeaders`. Widgets built with a bundler target below ES2017 (e.g. `target: 'es5'` or `target: 'es6'` in webpack/Rollup) that run in environments without a native `Headers` implementation must add a polyfill such as [`whatwg-fetch`](https://github.com/github/fetch) or [`cross-fetch`](https://github.com/lquixada/cross-fetch).

--- a/packages/plugin-graphql-client/src/__tests__/indexSpec.js
+++ b/packages/plugin-graphql-client/src/__tests__/indexSpec.js
@@ -105,6 +105,9 @@ describe('createWidget method with graphql client plugin', () => {
         "transformers": [
           {
             "transformRequest": [Function],
+          },
+          {
+            "transformRequest": [Function],
             "transformResponse": [Function],
           },
           {

--- a/packages/plugin-http-cache/src/__tests__/indexSpec.js
+++ b/packages/plugin-http-cache/src/__tests__/indexSpec.js
@@ -108,6 +108,9 @@ describe('createWidget method with http client plugin', () => {
         "transformers": [
           {
             "transformRequest": [Function],
+          },
+          {
+            "transformRequest": [Function],
             "transformResponse": [Function],
           },
           {

--- a/packages/plugin-http-client/src/__tests__/indexSpec.js
+++ b/packages/plugin-http-client/src/__tests__/indexSpec.js
@@ -3,6 +3,7 @@ import {
   httpClientPlugin,
   setDefaultConfig,
   getDefaultTransformers,
+  transformHeaders,
 } from '../index';
 
 describe('createWidget method with http client plugin', () => {
@@ -95,6 +96,9 @@ describe('createWidget method with http client plugin', () => {
         "transformers": [
           {
             "transformResponse": [Function],
+          },
+          {
+            "transformRequest": [Function],
           },
           {
             "transformRequest": [Function],
@@ -232,6 +236,95 @@ describe('createWidget method with http client plugin', () => {
       });
 
       expect(request.body).toMatchInlineSnapshot(`"{"a":"b"}"`);
+    });
+
+    it('should set default Content-Type application/json for POST with body', async () => {
+      const { request } = await widget.http.request({
+        method: 'POST',
+        path: '/path',
+        body: { a: 'b' },
+        headers: {},
+      });
+
+      expect(request.headers.get('Content-Type')).toBe('application/json');
+      expect(request.body).toMatchInlineSnapshot(`"{"a":"b"}"`);
+    });
+
+    it('should not override explicit Content-Type when body is present', async () => {
+      const { request } = await widget.http.request({
+        method: 'POST',
+        path: '/path',
+        body: 'raw text',
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+      });
+
+      expect(request.headers.get('Content-Type')).toBe('text/plain');
+      expect(request.body).toBe('raw text');
+    });
+
+    it('should not set default Content-Type for GET with body', async () => {
+      const { request } = await widget.http.request({
+        method: 'GET',
+        path: '/path',
+        body: { a: 'b' },
+        headers: {},
+      });
+
+      expect(request.headers.get('Content-Type')).toBeNull();
+    });
+
+    it('should set default Content-Type when headers is a Headers instance', async () => {
+      const { request } = await widget.http.request({
+        method: 'POST',
+        path: '/path',
+        body: { a: 'b' },
+        headers: new Headers(),
+      });
+
+      expect(request.headers.get('Content-Type')).toBe('application/json');
+      expect(request.body).toMatchInlineSnapshot(`"{"a":"b"}"`);
+    });
+
+    it('should serialize body when headers is a Headers instance with Content-Type', async () => {
+      const { request } = await widget.http.request({
+        method: 'POST',
+        path: '/path',
+        body: { a: 'b' },
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+      });
+
+      expect(request.headers.get('content-type')).toBe('application/json');
+      expect(request.body).toMatchInlineSnapshot(`"{"a":"b"}"`);
+    });
+
+    it('should not override Content-Type when headers is a Headers instance with custom type', async () => {
+      const { request } = await widget.http.request({
+        method: 'POST',
+        path: '/path',
+        body: 'raw',
+        headers: new Headers({ 'Content-Type': 'text/plain' }),
+      });
+
+      expect(request.headers.get('content-type')).toBe('text/plain');
+      expect(request.body).toBe('raw');
+    });
+
+    it('should preserve existing entries when headers is a Headers instance', async () => {
+      const { request } = await widget.http.request({
+        method: 'POST',
+        path: '/path',
+        body: { a: 'b' },
+        headers: new Headers({
+          Authorization: 'Bearer token',
+          'X-Request-ID': '42',
+        }),
+      });
+
+      expect(request.headers.get('Authorization')).toBe('Bearer token');
+      expect(request.headers.get('X-Request-ID')).toBe('42');
+      expect(request.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('should timeout request which exceed predefined timeout limit', async () => {
@@ -424,5 +517,54 @@ describe('createWidget method with http client plugin', () => {
       expect(errorTransformerSpy).not.toHaveBeenCalled();
       expect(widget.$dependencies.fetch).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('transformHeaders', () => {
+  const transformer = transformHeaders();
+
+  it('should normalize a plain object to a Headers instance', async () => {
+    const [result] = await transformer.transformRequest(
+      null,
+      { headers: { Authorization: 'Bearer token' } },
+      null,
+    );
+
+    expect(result.headers).toBeInstanceOf(Headers);
+    expect(result.headers.get('Authorization')).toBe('Bearer token');
+  });
+
+  it('should normalize a Headers instance to a new Headers instance', async () => {
+    const input = new Headers({ 'X-Custom': 'value' });
+    const [result] = await transformer.transformRequest(
+      null,
+      { headers: input },
+      null,
+    );
+
+    expect(result.headers).toBeInstanceOf(Headers);
+    expect(result.headers.get('X-Custom')).toBe('value');
+  });
+
+  it('should normalize null headers to an empty Headers instance', async () => {
+    const [result] = await transformer.transformRequest(
+      null,
+      { headers: null },
+      null,
+    );
+
+    expect(result.headers).toBeInstanceOf(Headers);
+    expect([...result.headers.entries()]).toHaveLength(0);
+  });
+
+  it('should preserve the response unchanged', async () => {
+    const response = { ok: true };
+    const [, resultResponse] = await transformer.transformRequest(
+      null,
+      { headers: {} },
+      response,
+    );
+
+    expect(resultResponse).toBe(response);
   });
 });

--- a/packages/plugin-http-client/src/index.js
+++ b/packages/plugin-http-client/src/index.js
@@ -1,5 +1,8 @@
 import { assignMissingKeys, bindWidgetToFunctions } from '@merkur/core';
 
+const CONTENT_TYPE_HEADER = 'Content-Type';
+const CONTENT_TYPE_JSON = 'application/json';
+
 export function setDefaultConfig(widget, newDefaultConfig) {
   widget.$in.httpClient.defaultConfig = {
     ...widget.$in.httpClient.defaultConfig,
@@ -9,6 +12,7 @@ export function setDefaultConfig(widget, newDefaultConfig) {
 
 export function getDefaultTransformers(widget) {
   return [
+    transformHeaders(widget),
     transformBody(widget),
     transformQuery(widget),
     transformTimeout(widget),
@@ -163,6 +167,17 @@ export function transformQuery() {
   };
 }
 
+export function transformHeaders() {
+  return {
+    async transformRequest(widget, request, response) {
+      return [
+        { ...request, headers: new Headers(request.headers ?? {}) },
+        response,
+      ];
+    },
+  };
+}
+
 export function transformBody() {
   return {
     async transformResponse(widget, request, response) {
@@ -170,7 +185,7 @@ export function transformBody() {
         const contentType = response.headers.get('content-type');
         let body = null;
 
-        if (contentType && contentType.includes('application/json')) {
+        if (contentType && contentType.includes(CONTENT_TYPE_JSON)) {
           body = await response.json();
         } else {
           body = await response.text();
@@ -185,20 +200,24 @@ export function transformBody() {
       return [request, response];
     },
     async transformRequest(widget, request, response) {
-      const { body, headers, method } = request;
+      const { body, method } = request;
+      const newHeaders = new Headers(request.headers);
+      const isBodyMethod = !['GET', 'HEAD'].includes(method);
 
-      if (
-        body &&
-        (headers['Content-Type'] || headers['content-type']) ===
-          'application/json' &&
-        !['GET', 'HEAD'].includes(method)
-      ) {
-        let newRequest = { ...request, body: JSON.stringify(body) };
+      if (body && isBodyMethod) {
+        if (!newHeaders.has(CONTENT_TYPE_HEADER)) {
+          newHeaders.set(CONTENT_TYPE_HEADER, CONTENT_TYPE_JSON);
+        }
 
-        return [newRequest, response];
+        if (newHeaders.get(CONTENT_TYPE_HEADER) === CONTENT_TYPE_JSON) {
+          return [
+            { ...request, headers: newHeaders, body: JSON.stringify(body) },
+            response,
+          ];
+        }
       }
 
-      return [request, response];
+      return [{ ...request, headers: newHeaders }, response];
     },
   };
 }

--- a/website/docs/http-client-plugin.md
+++ b/website/docs/http-client-plugin.md
@@ -98,14 +98,16 @@ try {
 
 #### POST request with JSON body, custom headers, and cookies
 
+When a request has a `body` and uses a method that supports a body (anything other than `GET` or `HEAD`), `Content-Type: application/json` is set automatically. You can override it by providing your own `Content-Type` header.
+
 Cookies are sent automatically for same-origin requests. For cross-origin requests set `credentials` to `'include'`. Custom headers such as `Authorization` or `X-Request-ID` can be passed via the `headers` option:
 
 ```javascript
+// Content-Type: application/json is added automatically
 const { response } = await widget.http.request({
   method: 'POST',
   path: '/items',
   headers: {
-    'Content-Type': 'application/json',
     Authorization: 'Bearer my-access-token',
     'X-Request-ID': 'abc-123',
   },
@@ -115,6 +117,14 @@ const { response } = await widget.http.request({
 
 console.log(response.status); // 201
 console.log(response.body);   // { id: 123, name: 'New item', value: 42 }
+
+// Override the default Content-Type when sending a different body format:
+const { response: uploadResponse } = await widget.http.request({
+  method: 'POST',
+  path: '/upload',
+  headers: { 'Content-Type': 'multipart/form-data' },
+  body: formData,
+});
 ```
 
 #### Sending query parameters
@@ -153,9 +163,9 @@ Merges `newDefaultConfig` shallowly into the widget's existing default request c
 | `baseUrl` | `string` | `''` | Base URL prepended to `path` |
 | `path` | `string` | `'/'` | Path appended to `baseUrl` |
 | `url` | `string` | — | Full URL; if set, `baseUrl` and `path` are ignored |
-| `headers` | `object` | `{}` | Request headers |
+| `headers` | `object \| `[Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers)`` | `{}` | Request headers — plain objects and `Headers` instances are both accepted |
 | `query` | `object` | `{}` | Key/value pairs encoded as query string |
-| `body` | `any` | — | Request body; serialized to JSON when `Content-Type: application/json` |
+| `body` | `any` | — | Request body; serialized to JSON when `Content-Type` is `application/json` (set automatically for body-bearing methods — overridable) |
 | `timeout` | `number` | `15000` | Abort timeout in milliseconds |
 | `transformers` | `Array` | built-ins | Transformer pipeline (see [Built-in transformers](#built-in-transformers)) |
 | *(fetch options)* | | | Any option accepted by the native [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Supplying_request_options) (e.g. `credentials`, `mode`, `cache`) |
@@ -184,11 +194,12 @@ export const widgetProperties = {
 getDefaultTransformers(widget) // returns Array<HttpTransformer>
 ```
 
-Returns the three built-in transformer instances in their default execution order:
+Returns the four built-in transformer instances in their default execution order:
 
-1. `transformBody` — serializes the request body and deserializes the response body
-2. `transformQuery` — builds the request URL from `baseUrl` + `path` and appends `query` parameters
-3. `transformTimeout` — sets up an `AbortController`-based request timeout
+1. `transformHeaders` — normalizes `request.headers` to a [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) instance
+2. `transformBody` — serializes the request body and deserializes the response body
+3. `transformQuery` — builds the request URL from `baseUrl` + `path` and appends `query` parameters
+4. `transformTimeout` — sets up an `AbortController`-based request timeout
 
 Spread the result into a custom `transformers` array to preserve default behaviour while adding your own transformers:
 
@@ -204,7 +215,7 @@ setDefaultConfig(widget, {
 });
 ```
 
-Omitting `getDefaultTransformers` (i.e. providing a `transformers` array that does not include them) means URL building, body serialization, and timeouts no longer happen automatically.
+Omitting `getDefaultTransformers` (i.e. providing a `transformers` array that does not include them) means header normalization, URL building, body serialization, and timeouts no longer happen automatically.
 
 ## Key behaviors
 
@@ -269,11 +280,37 @@ function transformCache(cache) {
 
 ## Built-in transformers
 
+### transformHeaders
+
+Normalizes `request.headers` to a [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) instance. Both plain objects and existing `Headers` instances are accepted as input. After this transformer runs, all subsequent transformers in the pipeline receive `request.headers` as a `Headers` instance and should use the `Headers` API (`.get()`, `.set()`, `.has()`) to read or modify headers.
+
+**`transformRequest`** — Converts `request.headers` to `new Headers(request.headers ?? {})`.
+
+```javascript
+// Both forms are accepted as input:
+await widget.http.request({ headers: { Authorization: 'Bearer token' } });
+await widget.http.request({ headers: new Headers({ Authorization: 'Bearer token' }) });
+
+// In a custom transformer placed after transformHeaders, use the Headers API:
+function transformAuth(getToken) {
+  return {
+    async transformRequest(widget, request, response) {
+      request.headers.set('Authorization', `Bearer ${getToken()}`);
+      return [request, response];
+    },
+  };
+}
+```
+
 ### transformBody
 
 Handles serialization of the request body and deserialization of the response body.
 
-**`transformRequest`** — When `body` is set and `Content-Type: application/json` is present in the request headers and the method is not `GET` or `HEAD`, the body is serialized with `JSON.stringify`.
+**`transformRequest`** — When `body` is set and the method is not `GET` or `HEAD`:
+- If no `Content-Type` header is present, `Content-Type: application/json` is added automatically.
+- If the effective `Content-Type` is `application/json`, the body is serialized with `JSON.stringify`.
+
+The default `Content-Type` can be overridden by explicitly setting a different value in the request `headers`.
 
 **`transformResponse`** — After a successful fetch, reads the response stream:
 - `application/json` content-type → parsed with `response.json()`
@@ -281,14 +318,21 @@ Handles serialization of the request body and deserialization of the response bo
 - HTTP 204 No Content → response is passed through unchanged (no body reading)
 
 ```javascript
-// Sending and receiving JSON:
+// Content-Type: application/json is set automatically — body is serialized:
 const { response } = await widget.http.request({
   method: 'POST',
   path: '/items',
-  headers: { 'Content-Type': 'application/json' },
-  body: { name: 'widget', count: 3 }, // automatically serialized
+  body: { name: 'widget', count: 3 },
 });
 console.log(response.body); // { id: 7, name: 'widget', count: 3 } — automatically parsed
+
+// Override to send a different content type:
+const { response: r } = await widget.http.request({
+  method: 'PUT',
+  path: '/blob',
+  headers: { 'Content-Type': 'application/octet-stream' },
+  body: buffer,
+});
 ```
 
 ### transformQuery
@@ -346,16 +390,13 @@ Called before the fetch is made. Receives `(widget, request, response)` and must
 
 ```javascript
 // Inject an Authorization header into every request:
+// request.headers is a Headers instance after transformHeaders runs (first in the default pipeline).
 function transformAuth(getToken) {
   return {
     async transformRequest(widget, request, response) {
-      return [
-        {
-          ...request,
-          headers: { ...request.headers, Authorization: `Bearer ${getToken()}` },
-        },
-        response,
-      ];
+      const headers = new Headers(request.headers);
+      headers.set('Authorization', `Bearer ${getToken()}`);
+      return [{ ...request, headers }, response];
     },
   };
 }


### PR DESCRIPTION
…nce, add default Content-Type for body requests

- Add transformHeaders transformer that normalizes request.headers to a Headers instance (accepts plain objects and Headers instances)
- Add transformHeaders as first entry in getDefaultTransformers pipeline
- Set default Content-Type: application/json for body-bearing requests (non-GET/HEAD) when no Content-Type is already set in transformBody
- Add changeset documenting all three breaking changes and migration steps
- Add tests for Headers instance normalization, default Content-Type, and preservation of existing headers
- Update website documentation